### PR TITLE
Fix checkout page + code cleanup

### DIFF
--- a/client/pages/checkout/[id].tsx
+++ b/client/pages/checkout/[id].tsx
@@ -1,8 +1,8 @@
 import { Box, Button, CircularProgress, Grid, Paper, Typography } from "@mui/material";
 import { useRouter } from "next/router";
-import { FC, PropsWithChildren, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { CheckoutStepper, AddressForm } from "../../components";
-import { GetServerSideProps } from "next";
+import { GetStaticProps, NextPage } from "next";
 import { AddressBody, CountryListResponse } from "../../interfaces";
 import { CheckoutLayout } from "../../layouts";
 import {
@@ -30,7 +30,7 @@ const bodyInitialState: AddressBody = {
   state: "",
   country: "",
 };
-const CheckoutPage: FC<PropsWithChildren<Props>> = ({ countryList }) => {
+const CheckoutPage: NextPage<Props> = ({ countryList }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const { payWithPaypal } = useCheckout();
@@ -241,23 +241,23 @@ const CheckoutPage: FC<PropsWithChildren<Props>> = ({ countryList }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  try {
-    const res = await fetch("https://restcountries.com/v2/all?fields=name");
-    const data: CountryListResponse[] = await res.json();
-    return {
-      props: {
-        countryList: data,
-      },
-    };
-  } catch (e) {
-    console.log(e);
-    return {
-      props: {
-        countryList: e,
-      },
-    };
-  }
+export const getStaticProps: GetStaticProps<{ countryList: CountryListResponse[] }> = async () => {
+  // try {
+  const res = await fetch("https://restcountries.com/v2/all?fields=name");
+  const data: CountryListResponse[] = await res.json();
+  return {
+    props: {
+      countryList: data,
+    },
+  };
+  // } catch (e) {
+  //   console.log(e);
+  //   return {
+  //     props: {
+  //       countryList: e,
+  //     },
+  //   };
+  // }
 };
 
 export default CheckoutPage;

--- a/client/pages/checkout/[id].tsx
+++ b/client/pages/checkout/[id].tsx
@@ -242,14 +242,22 @@ const CheckoutPage: FC<PropsWithChildren<Props>> = ({ countryList }) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async () => {
-  const res = await fetch("https://restcountries.com/v2/all?fields=name");
-  const data: CountryListResponse[] = await res.json();
-
-  return {
-    props: {
-      countryList: data,
-    },
-  };
+  try {
+    const res = await fetch("https://restcountries.com/v2/all?fields=name");
+    const data: CountryListResponse[] = await res.json();
+    return {
+      props: {
+        countryList: data,
+      },
+    };
+  } catch (e) {
+    console.log(e);
+    return {
+      props: {
+        countryList: e,
+      },
+    };
+  }
 };
 
 export default CheckoutPage;

--- a/client/pages/checkout/[id].tsx
+++ b/client/pages/checkout/[id].tsx
@@ -2,7 +2,7 @@ import { Box, Button, CircularProgress, Grid, Paper, Typography } from "@mui/mat
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { CheckoutStepper, AddressForm } from "../../components";
-import { GetStaticProps, NextPage } from "next";
+import { NextPage } from "next";
 import { AddressBody, CountryListResponse } from "../../interfaces";
 import { CheckoutLayout } from "../../layouts";
 import {
@@ -241,21 +241,21 @@ const CheckoutPage: NextPage<Props> = ({ countryList }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps<{ countryList: CountryListResponse[] }> = async () => {
+CheckoutPage.getInitialProps = async () => {
   // try {
   const res = await fetch("https://restcountries.com/v2/all?fields=name");
   const data: CountryListResponse[] = await res.json();
   return {
-    props: {
-      countryList: data,
-    },
+    // props: {
+    countryList: data,
+    // },
   };
   // } catch (e) {
   //   console.log(e);
   //   return {
   //     props: {
-  //       countryList: e,
-  //     },
+  //       countryList: e
+  //     }
   //   };
   // }
 };

--- a/client/pages/checkout/[id].tsx
+++ b/client/pages/checkout/[id].tsx
@@ -242,22 +242,11 @@ const CheckoutPage: NextPage<Props> = ({ countryList }) => {
 };
 
 CheckoutPage.getInitialProps = async () => {
-  // try {
   const res = await fetch("https://restcountries.com/v2/all?fields=name");
   const data: CountryListResponse[] = await res.json();
   return {
-    // props: {
     countryList: data,
-    // },
   };
-  // } catch (e) {
-  //   console.log(e);
-  //   return {
-  //     props: {
-  //       countryList: e
-  //     }
-  //   };
-  // }
 };
 
 export default CheckoutPage;

--- a/client/utils/hooks/useCheckout.ts
+++ b/client/utils/hooks/useCheckout.ts
@@ -38,7 +38,6 @@ export default function useCheckout() {
     setCheckoutError(undefined);
     try {
       const { successful, message, data } = await newOrder(cartItems).unwrap();
-      console.log(data);
       if (successful) {
         await router.push(`/checkout/${data}`);
       } else {


### PR DESCRIPTION
1. Checkout page now uses getInitialProps instead of getServerSiderendering
2. Remove console.log()
3. Remove unused comments